### PR TITLE
[Fix] Fix Adam optimizer and lower the defualt lr

### DIFF
--- a/minitorch/optim.py
+++ b/minitorch/optim.py
@@ -87,7 +87,7 @@ class Adam(Optimizer):
 
                     state['step'] += 1
                     state['exp_avg'] = state['exp_avg'] * self.beta1 + (1 - self.beta1) * grad
-                    state['exp_avg_sq'] = state['exp_avg_sq'] * self.beta2 + (1 - self.beta1) * grad ** 2
+                    state['exp_avg_sq'] = state['exp_avg_sq'] * self.beta2 + (1 - self.beta2) * grad ** 2
 
                     denom = state['exp_avg_sq'] ** 0.5 + self.eps
 

--- a/project/run_sentiment.py
+++ b/project/run_sentiment.py
@@ -315,7 +315,7 @@ def encode_sentiment_data(dataset, pretrained_embeddings, N_train, N_val=0):
 if __name__ == "__main__":
     train_size = 450
     validation_size = 100
-    learning_rate = 0.25
+    learning_rate = 0.025
     max_epochs = 250
     embedding_dim = 50
 


### PR DESCRIPTION
Fix `(1 - self.beta1)` → `(1 - self.beta2)` in Adam second moment update.
Lower default lr from 0.25 to 0.025 accordingly.